### PR TITLE
[OWL-528] Use Alpine as base image to reduce the image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,17 +11,22 @@ VOLUME $CONFIGDIR $WORKDIR
 COPY $CONFIGFILE $CONFIGDIR/
 ADD $PACKFILE $WORKDIR
 
-WORKDIR /root
-COPY run.sh ./
+WORKDIR $WORKDIR
+COPY run.sh $WORKDIR
 
+# Set timezone & bash
+# Set alias in the case of user want to execute control in their terminal
 RUN \
-  apk add --update bash && \
-  echo "alias ps='pstree'" > ~/.bashrc && \
-  rm -rf /var/cache/apk/*
+  apk add --update tzdata bash \
+  && cp /usr/share/zoneinfo/Asia/Taipei /etc/localtime \
+  && echo "Asia/Taipei" > /etc/timezone \
+  && apk del tzdata \
+  && rm -rf /var/cache/apk/* \
+  && echo "alias ps='pstree'" > ~/.bashrc
 
 # Port
 EXPOSE 9912
 
 # Start
-CMD ["./run.sh"]
+CMD ["bash", "run.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN \
   apk add --no-cache tzdata bash \
   && cp /usr/share/zoneinfo/Asia/Taipei /etc/localtime \
   && echo "Asia/Taipei" > /etc/timezone \
-  && apk del tzdata \
   && echo "alias ps='pstree'" > ~/.bashrc \
   && mkdir -p $CONFIGDIR
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,25 +4,23 @@ MAINTAINER minimum@cepave.com
 
 ENV WORKDIR=/home/alarm PACKFILE=falcon-alarm.tar.gz CONFIGDIR=/config CONFIGFILE=cfg.json
 
-# Volume
-VOLUME $CONFIGDIR $WORKDIR
+# Set timezone, bash, config dir
+# Set alias in the case of user want to execute control in their terminal
+RUN \
+  apk add --no-cache tzdata bash \
+  && cp /usr/share/zoneinfo/Asia/Taipei /etc/localtime \
+  && echo "Asia/Taipei" > /etc/timezone \
+  && apk del tzdata \
+  && echo "alias ps='pstree'" > ~/.bashrc \
+  && mkdir -p $CONFIGDIR
 
 # Install Open-Falcon Alarm Component
 COPY $CONFIGFILE $CONFIGDIR/
 ADD $PACKFILE $WORKDIR
+RUN ln -snf $CONFIGDIR/$CONFIGFILE $WORKDIR/$CONFIGFILE
 
 WORKDIR $WORKDIR
 COPY run.sh $WORKDIR
-
-# Set timezone & bash
-# Set alias in the case of user want to execute control in their terminal
-RUN \
-  apk add --update tzdata bash \
-  && cp /usr/share/zoneinfo/Asia/Taipei /etc/localtime \
-  && echo "Asia/Taipei" > /etc/timezone \
-  && apk del tzdata \
-  && rm -rf /var/cache/apk/* \
-  && echo "alias ps='pstree'" > ~/.bashrc
 
 # Port
 EXPOSE 9912

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,23 @@
-FROM ubuntu:14.04.2
+FROM alpine:3.4
 
 MAINTAINER minimum@cepave.com
 
-ENV WORKDIR=/home/alarm PACKDIR=/package PACKFILE=falcon-alarm.tar.gz CONFIGDIR=/config CONFIGFILE=cfg.json
+ENV WORKDIR=/home/alarm PACKFILE=falcon-alarm.tar.gz CONFIGDIR=/config CONFIGFILE=cfg.json
 
 # Volume
-VOLUME $CONFIGDIR $WORKDIR $PACKDIR
+VOLUME $CONFIGDIR $WORKDIR
 
 # Install Open-Falcon Alarm Component
 COPY $CONFIGFILE $CONFIGDIR/
-COPY $PACKFILE $PACKDIR/
+ADD $PACKFILE $WORKDIR
 
 WORKDIR /root
 COPY run.sh ./
+
+RUN \
+  apk add --update bash && \
+  echo "alias ps='pstree'" > ~/.bashrc && \
+  rm -rf /var/cache/apk/*
 
 # Port
 EXPOSE 9912

--- a/run.sh
+++ b/run.sh
@@ -1,11 +1,26 @@
 #!/bin/bash
 
+#
+# Note that this file should be put under the same directory
+# with control script for 2 reasons:
+#
+# 1. This file sets the alias then source the script to
+#     retain the setting for the purpose of making control
+#     script work normally on Alpine without modification.
+# 2. The control script will change its working directory.
+#
+
 APP="falcon-alarm"
 WAIT_SERVICE_READY=10
 
+# Expand alias to make control compatible with Alpine
+alias ps='pstree'
+shopt -s expand_aliases
+
 check_service()
 {
-  status=$(bash -i $WORKDIR/control status)
+  # Source the script to retain the alias
+  status=$(source $WORKDIR/control status)
   echo $status | grep -q "stoped"
   if [ $? -eq 0 ] ; then
     return 1
@@ -16,7 +31,8 @@ check_service()
 
 cp $CONFIGDIR/$CONFIGFILE $WORKDIR
 
-bash -i $WORKDIR/control restart
+# Source the script to retain the alias
+source $WORKDIR/control restart
 while sleep $WAIT_SERVICE_READY; do
   check_service
   if [ $? -eq 1 ] ; then

--- a/run.sh
+++ b/run.sh
@@ -3,8 +3,9 @@
 APP="falcon-alarm"
 WAIT_SERVICE_READY=10
 
-function check_service(){
-  status=$($WORKDIR/control status)
+check_service()
+{
+  status=$(bash -i $WORKDIR/control status)
   echo $status | grep -q "stoped"
   if [ $? -eq 0 ] ; then
     return 1
@@ -13,10 +14,9 @@ function check_service(){
   fi
 }
 
-tar -zxf $PACKDIR/$PACKFILE -C $WORKDIR
 cp $CONFIGDIR/$CONFIGFILE $WORKDIR
 
-$WORKDIR/control restart
+bash -i $WORKDIR/control restart
 while sleep $WAIT_SERVICE_READY; do
   check_service
   if [ $? -eq 1 ] ; then

--- a/run.sh
+++ b/run.sh
@@ -29,8 +29,6 @@ check_service()
   fi
 }
 
-cp $CONFIGDIR/$CONFIGFILE $WORKDIR
-
 # Source the script to retain the alias
 source $WORKDIR/control restart
 while sleep $WAIT_SERVICE_READY; do

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+APP="falcon-alarm"
 WAIT_SERVICE_READY=10
 
 function check_service(){
@@ -14,12 +15,12 @@ function check_service(){
 
 tar -zxf $PACKDIR/$PACKFILE -C $WORKDIR
 cp $CONFIGDIR/$CONFIGFILE $WORKDIR
+
 $WORKDIR/control restart
-sleep $WAIT_SERVICE_READY
-check_service
-if [ $? -eq 0 ] ; then
-  $WORKDIR/control tail
-else
-  echo "Failed to start."
-  exit 1
-fi
+while sleep $WAIT_SERVICE_READY; do
+  check_service
+  if [ $? -eq 1 ] ; then
+    echo "$APP exited"
+    exit 1
+  fi
+done


### PR DESCRIPTION
Replace ubuntu with alpine as base image.
Use alias in running script to solve the control compatibility problem.
Remove VOLUME to avoid the change discarded problem.
